### PR TITLE
make calculateTransferTime in RailwaySystem public

### DIFF
--- a/src/main/RailConnectGUI.java
+++ b/src/main/RailConnectGUI.java
@@ -490,7 +490,8 @@ public class RailConnectGUI extends Application {
                         Segment nextSeg = trip.getSegments().get(i + 1);
                         Connection nextConn = nextSeg.getConnection();
 
-                        int transferTime = layoverMinutesAcrossDays(conn, nextConn, currentArrivalDay);
+                        // int transferTime = layoverMinutesAcrossDays(conn, nextConn, currentArrivalDay);
+                        int transferTime = system.calculateTransferTime(conn, nextConn);
                         totalTransferTime += transferTime;
                         sb.append("     Transfer time (including days wait): " + formatDuration(transferTime) + "\n");
 

--- a/src/main/RailwaySystem.java
+++ b/src/main/RailwaySystem.java
@@ -141,6 +141,10 @@ public class RailwaySystem {
         // Find all first legs departing from origin
         List<Connection> firstSegments = connections.findMatching(depCity, null, depTime, null, trainType, daysOp);
         
+        // Define restrictions on layover times
+        short minLayoverMinutes = 30;       // At least 30 mins to allow for passengers to switch trains
+        short maxDayLayoverMinutes = 540;   // At most 9 hours during the day
+
         if(startDay != null) {
             firstSegments.removeIf(conn -> !parseDays(conn.getDaysOfOperation()).contains(startDay));
         }
@@ -150,6 +154,12 @@ public class RailwaySystem {
 
             for (Connection secondSegment : secondSegments) {
                 int transferTime = calculateTransferTime(firstSegment, secondSegment);
+                
+                // Handle layover time limits
+                if (transferTime < minLayoverMinutes || transferTime > maxDayLayoverMinutes) {
+                    continue;
+                }
+
                 Trip trip = new Trip();
                 trip.addSegment(new Segment(firstSegment));
                 trip.addSegment(new Segment(secondSegment));
@@ -167,6 +177,10 @@ public class RailwaySystem {
 
         // Find all first legs departing from origin
         List<Connection> firstSegments = connections.findMatching(depCity, null, depTime, null, trainType, daysOp);
+
+        // Define restrictions on layover times
+        short minLayoverMinutes = 30;       // At least 30 mins to allow for passengers to switch trains
+        short maxDayLayoverMinutes = 540;   // At most 9 hours during the day
 
         if(startDay != null){
             firstSegments.removeIf(conn -> !parseDays(conn.getDaysOfOperation()).contains(startDay));
@@ -193,6 +207,14 @@ public class RailwaySystem {
                     int transferTime1 = calculateTransferTime(firstSegment, secondSegment);
                     int transferTime2 = calculateTransferTime(secondSegment, thirdSegment);
 
+                    // Handle layover time limits
+                    if (transferTime1 < minLayoverMinutes || transferTime1 > maxDayLayoverMinutes) {
+                        continue; // Skip adding this segment
+                    } else if (transferTime2 < minLayoverMinutes || transferTime2 > maxDayLayoverMinutes) {
+                        continue;
+                    }
+
+                    
                     Trip trip = new Trip();
                     trip.addSegment(new Segment(firstSegment));
                     trip.addSegment(new Segment(secondSegment));
@@ -222,7 +244,7 @@ public class RailwaySystem {
         }
     }
 
-    private int calculateTransferTime(Connection firstSegment, Connection secondSegment) {
+    public int calculateTransferTime(Connection firstSegment, Connection secondSegment) {
         int arrivalMinutes = firstSegment.getArrivalTime().getHour() * 60 + firstSegment.getArrivalTime().getMinute();
         int departureMinutes = secondSegment.getDepartureTime().getHour() * 60
                 + secondSegment.getDepartureTime().getMinute();


### PR DESCRIPTION
now using calculateTransferTime to calculate transfer times in the GUI text field, and add restrictions to only allow for transfer times between 30 minutes and 9 hours.

Closes #65 